### PR TITLE
Deanonymizing by transactions and blocks

### DIFF
--- a/backend/src/polydash/__main__.py
+++ b/backend/src/polydash/__main__.py
@@ -1,23 +1,26 @@
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routers import node, block, dashboard
+from .routers import node, block, dashboard, deanon
 from .db import start_db
 from .block_retriever.retriever import start_retriever
 from .rating.live_time_heuristic import start_live_time_heuristic
 from .rating.live_time_heuristic_a import start_live_time_heuristic_a
+from .deanonymize.deanonymizer import start_deanonymizer
 
 # Modules set up
 start_db()
 start_retriever()
 start_live_time_heuristic()
 start_live_time_heuristic_a()
+start_deanonymizer()
 
 # FastAPI set up
 app = FastAPI()
 app.include_router(node.router)
 app.include_router(block.router)
 app.include_router(dashboard.router)
+app.include_router(deanon.router)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Allows all origins

--- a/backend/src/polydash/block_retriever/retriever.py
+++ b/backend/src/polydash/block_retriever/retriever.py
@@ -93,7 +93,7 @@ def get_block_author(number):
 def retriever_thread():
     LOGGER.info("block retrieved thread has started")
     # set to None to begin from the latest block; set to some block ID to begin with it
-    # next_block_number = 44562269
+    # next_block_number = 45784564
     next_block_number = None
     failure_count = 0
     while True:

--- a/backend/src/polydash/block_retriever/retriever.py
+++ b/backend/src/polydash/block_retriever/retriever.py
@@ -9,53 +9,63 @@ from polydash.log import LOGGER
 from polydash.definitions import ALCHEMY_TOKEN_FILE
 from polydash.rating.live_time_heuristic import EventQueue
 from polydash.rating.live_time_heuristic_a import BlockPoolHeuristicQueue
+from polydash.deanonymize.deanonymizer import DeanonymizerQueue
 
-alchemy_token = ''
+alchemy_token = ""
 
 
 def get_alchemy_url():
     global alchemy_token
     if len(alchemy_token) == 0:
-        with open(ALCHEMY_TOKEN_FILE, 'r') as file:
+        with open(ALCHEMY_TOKEN_FILE, "r") as file:
             alchemy_token = file.read()
 
     return "https://polygon-mainnet.g.alchemy.com/v2/{}".format(alchemy_token.strip())
 
 
 def make_request(rpc_method, params):
-    payload = {
-        "jsonrpc": "2.0",
-        "method": rpc_method,
-        "params": params
-    }
-    headers = {
-        "accept": "application/json",
-        "content-type": "application/json"
-    }
+    payload = {"jsonrpc": "2.0", "method": rpc_method, "params": params}
+    headers = {"accept": "application/json", "content-type": "application/json"}
     response = requests.post(get_alchemy_url(), json=payload, headers=headers)
     if response.status_code != 200:
-        LOGGER.error('could not make a request: {}, {}'.format(response.status_code, response.text))
+        LOGGER.error(
+            "could not make a request: {}, {}".format(
+                response.status_code, response.text
+            )
+        )
         return None
 
     json_response = json.loads(response.text)
     if json_response is None:
-        LOGGER.error('could not make a request: json_response is None')
+        LOGGER.error("could not make a request: json_response is None")
         return None
-    if 'error' in json_response:
-        LOGGER.error('could not make a request: error in the response: {}'.format(json_response['error']))
+    if "error" in json_response:
+        LOGGER.error(
+            "could not make a request: error in the response: {}".format(
+                json_response["error"]
+            )
+        )
         return None
-    return json_response['result']
+    return json_response["result"]
 
 
 def get_block(number=None):
     # https://docs.alchemy.com/reference/eth-getblockbynumber-polygon
-    json_result = make_request('eth_getBlockByNumber', ["latest" if number is None else '0x{:x}'.format(number), True])
+    json_result = make_request(
+        "eth_getBlockByNumber",
+        ["latest" if number is None else "0x{:x}".format(number), True],
+    )
     if json_result is None:
         return None
 
-    return int(json_result['number'], 16), int(json_result['timestamp'], 16), json_result['hash'], [
-        (tx['hash'], tx['from']) for tx in
-        json_result['transactions']], parse_txs(json_result), int(json_result['baseFeePerGas'], 16)
+    return (
+        int(json_result["number"], 16),
+        int(json_result["timestamp"], 16),
+        json_result["hash"],
+        [(tx["hash"], tx["from"]) for tx in json_result["transactions"]],
+        parse_txs(json_result),
+        int(json_result["baseFeePerGas"], 16),
+    )
 
 
 def parse_txs(json_result):
@@ -66,7 +76,6 @@ def parse_txs(json_result):
             "gas_tip_cap": int(tx.get("maxPriorityFeePerGas", "0"), 16),
             "gas_fee_cap": int(tx.get("maxFeePerGas", "0"), 16),
             "nonce": int(tx["nonce"], 16),
-
         }
         for tx in json_result["transactions"]
         # if tx.get("to", None) is not None
@@ -78,24 +87,35 @@ def parse_txs(json_result):
 def get_block_author(number):
     # the result is just a string or None, so return it directly
     # https://docs.alchemy.com/reference/bor-getauthor-polygon
-    return make_request('bor_getAuthor', ['0x{:x}'.format(number)])
+    return make_request("bor_getAuthor", ["0x{:x}".format(number)])
 
 
 def retriever_thread():
-    LOGGER.info('block retrieved thread has started')
+    LOGGER.info("block retrieved thread has started")
     # set to None to begin from the latest block; set to some block ID to begin with it
     # next_block_number = 44562269
     next_block_number = None
     failure_count = 0
     while True:
         if failure_count > 3:
-            LOGGER.error('giving up trying to retrieve block {}, moving to the next one...'.format(next_block_number))
+            LOGGER.error(
+                "giving up trying to retrieve block {}, moving to the next one...".format(
+                    next_block_number
+                )
+            )
             failure_count = 0
             next_block_number += 1
 
         try:
             # first, retrieve the block
-            (block_number, block_ts, block_hash, block_txs, block_txs_d, base_fee) = get_block(next_block_number)
+            (
+                block_number,
+                block_ts,
+                block_hash,
+                block_txs,
+                block_txs_d,
+                base_fee,
+            ) = get_block(next_block_number)
             if block_number is None:
                 failure_count += 1
                 continue
@@ -105,33 +125,61 @@ def retriever_thread():
             fetched_block_author = get_block_author(block_number)
             while fetched_block_author is None:
                 if author_failure_count > 5:
-                    raise 'could not retrieve the author of the block'
-                LOGGER.info('trying to retrieve the author of block {} again...'.format(block_number))
+                    raise "could not retrieve the author of the block"
+                LOGGER.info(
+                    "trying to retrieve the author of block {} again...".format(
+                        block_number
+                    )
+                )
                 time.sleep(0.5)
                 author_failure_count += 1
                 fetched_block_author = get_block_author(block_number)
 
             # finally, save it in DB
             with orm.db_session:
-                block = Block(number=block_number, hash=block_hash, validated_by=fetched_block_author)
+                block = Block(
+                    number=block_number,
+                    hash=block_hash,
+                    validated_by=fetched_block_author,
+                )
                 for tx in block_txs:
-                    block.transactions.add(Transaction(hash=tx[0], creator=tx[1], created=block_ts, block=block_number))
+                    block.transactions.add(
+                        Transaction(
+                            hash=tx[0],
+                            creator=tx[1],
+                            created=block_ts,
+                            block=block_number,
+                        )
+                    )
                 orm.commit()
                 EventQueue.put(block)  # put the block for the heuristics to be updated
-                BlockPoolHeuristicQueue.put((block_number, block_ts, block_hash, block_txs_d,
-                                             base_fee,
-                                             fetched_block_author))  # put the block data to the Heuristic A Queue
-            LOGGER.debug('retrieved and saved into DB block with number {} and hash {}'.format(block_number,
-                                                                                               block_hash))
+                BlockPoolHeuristicQueue.put(
+                    (
+                        block_number,
+                        block_ts,
+                        block_hash,
+                        block_txs_d,
+                        base_fee,
+                        fetched_block_author,
+                    )
+                )  # put the block data to the Heuristic A Queue
+                DeanonymizerQueue.put(
+                    block
+                )  # put the block for the deanon process to work
+            LOGGER.debug(
+                "retrieved and saved into DB block with number {} and hash {}".format(
+                    block_number, block_hash
+                )
+            )
 
             next_block_number = block_number + 1
             failure_count = 0
         except Exception as e:
             failure_count += 1
-            LOGGER.error('exception when retrieving block happened: {}'.format(e))
+            LOGGER.error("exception when retrieving block happened: {}".format(e))
         time.sleep(2)
 
 
 def start_retriever():
-    LOGGER.info('Starting block retriever thread...')
+    LOGGER.info("Starting block retriever thread...")
     threading.Thread(target=retriever_thread, daemon=True).start()

--- a/backend/src/polydash/deanonymize/deanonymizer.py
+++ b/backend/src/polydash/deanonymize/deanonymizer.py
@@ -1,0 +1,76 @@
+import queue
+import threading
+
+from pony import orm
+
+from polydash.log import LOGGER
+from polydash.model.block_p2p import BlockP2P
+from polydash.model.transaction_p2p import TransactionP2P
+from polydash.model.deanon_node_by_tx import DeanonNodeByTx
+from polydash.model.deanon_node_by_block import DeanonNodeByBlock
+
+DeanonymizerQueue = queue.Queue()
+
+
+@orm.db_session
+def calculate_confidence_by_block(block):
+    """
+    Increase the confidence of the relation between the peer, from which
+    we first saw this block, and the creator of this block
+    """
+    block_from_p2p = BlockP2P.get(block_hash=block.hash)
+    if block_from_p2p is None:
+        # we haven't seen this block over P2P, nothing can be done
+        return
+
+    # TODO: when this information is available, we increase the confidence using the 'from' field from BlockP2P
+
+
+@orm.db_session
+def calculate_confidence_by_tx(block):
+    """
+    Increase the confidence of the relation between the peer, from which
+    we first saw transactions from this block, and the creator of this block
+    """
+    for tx in block.transactions:
+        tx_p2p = TransactionP2P.get_by_sql(
+            'SELECT * FROM tx_summary WHERE tx_hash="{}" ORDER BY tx_first_seen LIMIT 1'.format(
+                tx.hash
+            )
+        )
+        if tx_p2p is None:
+            # we haven't seen it
+            return
+
+        deanon_node = DeanonNodeByTx.get(
+            signer_key=block.validated_by, peer_id=tx_p2p.peer_id
+        )
+        if deanon_node is None:
+            # no such node is remembered by us yet, create it
+            deanon_node = DeanonNodeByTx(
+                signer_key=block.validated_by, peer_id=tx_p2p.peer_id, confidence=1
+            )
+        else:
+            # just increase the confidence of this mapping
+            deanon_node.confidence += 1
+
+
+def main_loop():
+    while True:
+        try:
+            # get the block from some other thread
+            block = DeanonymizerQueue.get()
+
+            calculate_confidence_by_block(block)
+            calculate_confidence_by_tx(block)
+        except Exception as e:
+            LOGGER.error(
+                "exception when calculating the deanonymizer confidence happened: {}".format(
+                    str(e)
+                )
+            )
+
+
+def start_deanonymizer():
+    LOGGER.info("Starting Deanonymizer thread...")
+    threading.Thread(target=main_loop, daemon=True).start()

--- a/backend/src/polydash/model/block_p2p.py
+++ b/backend/src/polydash/model/block_p2p.py
@@ -1,0 +1,11 @@
+from pony import orm
+from polydash.db import db_p2p
+
+
+class BlockP2P(db_p2p.Entity):
+    _table_ = "block_fetched"
+    id = orm.PrimaryKey(int)
+    block_hash = orm.Optional(str)
+    block_number = orm.Optional(int)
+    first_seen_ts = orm.Optional(int)
+    # from = orm.Optional(str)

--- a/backend/src/polydash/model/block_p2p.py
+++ b/backend/src/polydash/model/block_p2p.py
@@ -8,4 +8,6 @@ class BlockP2P(db_p2p.Entity):
     block_hash = orm.Optional(str)
     block_number = orm.Optional(int)
     first_seen_ts = orm.Optional(int)
-    # from = orm.Optional(str)
+    peer = orm.Optional(str)
+    peer_remote_addr = orm.Optional(str)
+    peer_local_addr = orm.Optional(str)

--- a/backend/src/polydash/model/deanon_node_by_block.py
+++ b/backend/src/polydash/model/deanon_node_by_block.py
@@ -1,0 +1,20 @@
+from pony import orm
+from pydantic import BaseModel
+from polydash.db import db
+
+
+class DeanonNodeByBlock(db.Entity):
+    id = orm.PrimaryKey(int, auto=True)
+    signer_key = orm.Required(str)
+    peer_id = orm.Required(str)
+    confidence = orm.Required(int)
+
+
+class DeanonNodeByBlockInDB(BaseModel):
+    id: int
+    signer_key: str
+    peer_id: str
+    confidence: int
+
+    class Config:
+        orm_mode = True

--- a/backend/src/polydash/model/deanon_node_by_tx.py
+++ b/backend/src/polydash/model/deanon_node_by_tx.py
@@ -1,0 +1,20 @@
+from pony import orm
+from pydantic import BaseModel
+from polydash.db import db
+
+
+class DeanonNodeByTx(db.Entity):
+    id = orm.PrimaryKey(int, auto=True)
+    signer_key = orm.Required(str)
+    peer_id = orm.Required(str)
+    confidence = orm.Required(int)
+
+
+class DeanonNodeByTxInDB(BaseModel):
+    id: int
+    signer_key: str
+    peer_id: str
+    confidence: int
+
+    class Config:
+        orm_mode = True

--- a/backend/src/polydash/model/peer_to_ip.py
+++ b/backend/src/polydash/model/peer_to_ip.py
@@ -1,0 +1,18 @@
+from pony import orm
+from pydantic import BaseModel
+from polydash.db import db
+
+
+class PeerToIP(db.Entity):
+    id = orm.PrimaryKey(int, auto=True)
+    peer_id = orm.Required(str)
+    ip = orm.Required(str)
+
+
+class PeerToIPInDB(BaseModel):
+    id: int
+    peer_id: str
+    ip: str
+
+    class Config:
+        orm_mode = True

--- a/backend/src/polydash/routers/deanon.py
+++ b/backend/src/polydash/routers/deanon.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, HTTPException
+from pony import orm
+
+from polydash.model.deanon_node_by_tx import DeanonNodeByTx, DeanonNodeByTxInDB
+from polydash.model.deanon_node_by_block import DeanonNodeByBlock, DeanonNodeByBlockInDB
+
+router = APIRouter(
+    prefix="/deanon",
+    tags=["deanon"],
+    # dependencies=[Depends(get_token_header)],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get("/by_txs")
+async def get_all_mappings_by_txs():
+    with orm.db_session:
+        nodes = DeanonNodeByTx.select().sort_by(orm.desc(DeanonNodeByTx.confidence))
+        result = [DeanonNodeByTxInDB.from_orm(n) for n in nodes]
+    return result
+
+
+@router.get("/by_txs/by_pubkey/{pubkey}")
+async def get_by_txs_by_pubkey(pubkey: str):
+    with orm.db_session:
+        nodes = DeanonNodeByTx.select(signer_key=pubkey).sort_by(
+            orm.desc(DeanonNodeByTx.confidence)
+        )
+        result = [DeanonNodeByTxInDB.from_orm(n) for n in nodes]
+    return result
+
+
+@router.get("/by_txs/by_peer_id/{peer_id}")
+async def get_by_txs_by_peer_id(peer_id: str):
+    with orm.db_session:
+        nodes = DeanonNodeByTx.select(peer_id=peer_id).sort_by(
+            orm.desc(DeanonNodeByTx.confidence)
+        )
+        result = [DeanonNodeByTxInDB.from_orm(n) for n in nodes]
+    return result
+
+
+@router.get("/by_blocks")
+async def get_all_mappings_by_blocks():
+    with orm.db_session:
+        nodes = DeanonNodeByBlock.select().sort_by(
+            orm.desc(DeanonNodeByBlock.confidence)
+        )
+        result = [DeanonNodeByBlockInDB.from_orm(n) for n in nodes]
+    return result
+
+
+@router.get("/by_blocks/by_pubkey/{pubkey}")
+async def get_by_blocks_by_pubkey(pubkey: str):
+    with orm.db_session:
+        nodes = DeanonNodeByBlock.select(signer_key=pubkey).sort_by(
+            orm.desc(DeanonNodeByBlock.confidence)
+        )
+        result = [DeanonNodeByBlockInDB.from_orm(n) for n in nodes]
+    return result
+
+
+@router.get("/by_blocks/by_peer_id/{peer_id}")
+async def get_by_blocks_by_peer_id(peer_id: str):
+    with orm.db_session:
+        nodes = DeanonNodeByBlock.select(peer_id=peer_id).sort_by(
+            orm.desc(DeanonNodeByBlock.confidence)
+        )
+        result = [DeanonNodeByBlockInDB.from_orm(n) for n in nodes]
+    return result


### PR DESCRIPTION
This PR attempts to resolve pubkey to peer_id mapping by adding two new kinds of heuristics:
1. If the transaction is part of the block, validated by some peer `Pubkey`, and we saw it coming over P2P from `PeerId`, we can increase the confidence level that this `Pubkey` is actually behind that `PeerId`
2. Same goes for the block: if we first saw it coming from some peer, then it's probable that this peer is the validator of the block

So, this PR adds 3 new tables: `DeanonNodeByTx`, `DeanonNodeByBlock` and `PeerToIP`, the last one having a mapping between PeerIDs and IPs.

Related to #9 