### PR TITLE
Implement the transaction risk heuristic

### DIFF
--- a/backend/src/polydash/__main__.py
+++ b/backend/src/polydash/__main__.py
@@ -3,11 +3,12 @@ import yaml
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from polydash.settings import PolydashSettings
-from polydash.routers import node, block, dashboard, deanon
+from polydash.routers import node, block, dashboard, deanon, transaction_risk
 from polydash.db import start_db
 from polydash.block_retriever.retriever import BlockRetriever
 from polydash.rating.live_time_heuristic import start_live_time_heuristic
 from polydash.rating.live_time_heuristic_a import start_live_time_heuristic_a
+from polydash.rating.live_time_transaction import start_live_time_transaction_heuristic
 from polydash.deanonymize.deanonymizer import start_deanonymizer
 import click
 
@@ -17,6 +18,7 @@ app.include_router(node.router)
 app.include_router(block.router)
 app.include_router(dashboard.router)
 app.include_router(deanon.router)
+app.include_router(transaction_risk.router)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Allows all origins
@@ -44,6 +46,7 @@ def start(settings) -> PolydashSettings:
     start_live_time_heuristic()
     start_live_time_heuristic_a()
     start_deanonymizer()
+    start_live_time_transaction_heuristic()
 
     uvicorn.run(app, host=s.host, port=s.port)
 

--- a/backend/src/polydash/block_retriever/retriever.py
+++ b/backend/src/polydash/block_retriever/retriever.py
@@ -13,6 +13,7 @@ from polydash.rating.live_time_heuristic import EventQueue
 from polydash.rating.live_time_heuristic_a import BlockPoolHeuristicQueue
 from polydash.deanonymize.deanonymizer import DeanonymizerQueue
 from polydash.settings import BlockRetrieverSettings
+from polydash.rating.live_time_transaction import TransactionEventQueue
 
 alchemy_token = ""
 
@@ -89,7 +90,7 @@ class BlockRetriever:
     def retriever_thread(self):
         self.__logger.info("block retrieved thread has started")
         # set to None to begin from the latest block; set to some block ID to begin with it
-        # next_block_number = 45784564
+        # next_block_number = 44563210
         next_block_number = 0
         failure_count = 0
         while True:
@@ -162,6 +163,9 @@ class BlockRetriever:
                     DeanonymizerQueue.put(
                         block
                     )  # put the block for the deanon process to work
+                    TransactionEventQueue.put(
+                        block
+                    )  # put the block for the Transaction Risks to work
                 self.__logger.debug(
                     "retrieved and saved into DB block with number {} and hash {}".format(
                         block_number, block_hash

--- a/backend/src/polydash/model/block_p2p.py
+++ b/backend/src/polydash/model/block_p2p.py
@@ -6,7 +6,7 @@ from polydash.db import db
 class BlockP2P(db.Entity):
     _table_ = "block_fetched"
     id = orm.PrimaryKey(int, auto=True)
-    block_hash = orm.Optional(str)
+    block_hash = orm.Required(str, index=True)
     block_number = orm.Optional(int)
     first_seen_ts = orm.Optional(int)
     peer = orm.Optional(str)

--- a/backend/src/polydash/model/node_risk.py
+++ b/backend/src/polydash/model/node_risk.py
@@ -1,0 +1,18 @@
+from pony import orm
+from pydantic import BaseModel
+from polydash.db import db
+
+
+class NodeRisk(db.Entity):
+    pubkey = orm.PrimaryKey(str)
+    too_fast_txs = orm.Required(int)
+    too_slow_txs = orm.Required(int)
+
+
+class NodeRiskInDB(BaseModel):
+    pubkey: str
+    too_fast_txs: int
+    too_slow_txs: int
+
+    class Config:
+        orm_mode = True

--- a/backend/src/polydash/model/transaction_p2p.py
+++ b/backend/src/polydash/model/transaction_p2p.py
@@ -7,7 +7,7 @@ from polydash.model import GetOrInsertMixin
 
 class TransactionP2P(db.Entity, GetOrInsertMixin):
     _table_ = 'tx_summary'
-    tx_hash = orm.Required(str)
+    tx_hash = orm.Required(str, index=True)
     peer_id = orm.Required(str)
     PrimaryKey(tx_hash, peer_id)
     tx_first_seen = orm.Optional(int)

--- a/backend/src/polydash/model/transaction_risk.py
+++ b/backend/src/polydash/model/transaction_risk.py
@@ -1,0 +1,30 @@
+from pony import orm
+from pydantic import BaseModel
+from polydash.db import db
+from typing import Optional
+
+RISK_TOO_FAST = 0
+RISK_TOO_SLOW = 1
+
+
+class TransactionRisk(db.Entity):
+    id = orm.PrimaryKey(int, auto=True)
+    hash = orm.Required(str)
+    risk = orm.Optional(int)
+    live_time = orm.Required(int)
+    global_mean = orm.Required(float)
+    global_variance = orm.Required(float)
+    global_counted_txs = orm.Required(int)
+
+
+class TransactionRiskOut(BaseModel):
+    id: int
+    hash: str
+    risk: Optional[int]
+    live_time: int
+    global_mean: float
+    global_variance: float
+    global_counted_txs: int
+
+    class Config:
+        orm_mode = True

--- a/backend/src/polydash/rating/live_time_transaction.py
+++ b/backend/src/polydash/rating/live_time_transaction.py
@@ -1,0 +1,155 @@
+import queue
+import threading
+import math
+
+from pony import orm
+
+from polydash.log import LOGGER
+from polydash.model.transaction_p2p import TransactionP2P
+from polydash.model.node_risk import NodeRisk
+from polydash.model.transaction_risk import (
+    TransactionRisk,
+    RISK_TOO_FAST,
+    RISK_TOO_SLOW,
+)
+
+TransactionEventQueue = queue.Queue()
+
+# get updated with every call to calculate_mean_variance
+INITIALIZED_GLOBALS = False
+GLOBAL_MEAN = 0
+GLOBAL_VARIANCE = 0
+GLOBAL_COUNTED_TXS = 0
+
+
+def try_initialize_globals():
+    global INITIALIZED_GLOBALS
+    global GLOBAL_MEAN
+    global GLOBAL_VARIANCE
+    global GLOBAL_COUNTED_TXS
+
+    if INITIALIZED_GLOBALS:
+        return
+
+    # initialize the values of GLOBAL_MEAN & GLOBAL_VARIANCE with the last values from DB (if they exist)
+    with orm.db_session:
+        last_tx_risk = TransactionRisk.select_by_sql(
+            "SELECT * from TransactionRisk ORDER BY id DESC LIMIT 1"
+        )
+    if last_tx_risk is not None and len(last_tx_risk) != 0:
+        GLOBAL_MEAN = last_tx_risk[0].global_mean
+        GLOBAL_VARIANCE = last_tx_risk[0].global_variance
+        GLOBAL_COUNTED_TXS = last_tx_risk[0].global_counted_txs
+
+
+def calculate_mean_variance(new_value, old_mean, old_variance, old_number_of_values):
+    """
+    Pure function to calculate mean&variance of the new value taking into
+    account the old values and the size of the data set
+    """
+
+    # first, see if this value is an outlier in relation to the old values
+    too_low = False
+    too_big = False
+    if old_variance != 0:
+        deviation = (new_value - old_mean) / math.sqrt(old_variance)
+        too_low = deviation < -3
+        too_big = deviation > 3
+
+    # second, update the values of mean and variance
+    new_number_of_values = old_number_of_values + 1
+    new_mean = (old_mean * old_number_of_values + new_value) / new_number_of_values
+    if new_number_of_values > 1:
+        new_variance = (
+            (old_variance + old_mean**2) * old_number_of_values + new_value**2
+        ) / new_number_of_values - new_mean**2
+    else:
+        new_variance = 0
+
+    # return the results
+    return new_mean, new_variance, new_number_of_values, too_low, too_big
+
+
+def process_transaction(tx, node_pubkey):
+    # find the transaction in the list of the ones seen by P2P
+    with orm.db_session:
+        # Pony kept throwing exception at me with both generator and lambda select syntax, so raw SQL
+        tx_p2p = TransactionP2P.get_by_sql(
+            'SELECT * FROM tx_summary WHERE tx_hash="{}" ORDER BY tx_first_seen LIMIT 1'.format(
+                tx.hash
+            )
+        )
+        if tx_p2p is None:
+            # we haven't seen it
+            return
+
+    # get the live-time of this transaction
+    live_time = tx.created - tx_p2p.tx_first_seen
+    if live_time <= 0:
+        return
+
+    # calculate the values
+    global GLOBAL_MEAN
+    global GLOBAL_VARIANCE
+    global GLOBAL_COUNTED_TXS
+    mean, variance, counted_txs, too_low, too_big = calculate_mean_variance(
+        live_time, GLOBAL_MEAN, GLOBAL_VARIANCE, GLOBAL_COUNTED_TXS
+    )
+
+    # update the values
+    GLOBAL_MEAN = mean
+    GLOBAL_VARIANCE = variance
+    GLOBAL_COUNTED_TXS = counted_txs
+    risk = None
+    if too_low:
+        risk = RISK_TOO_SLOW
+    elif too_big:
+        risk = RISK_TOO_FAST
+
+    # save the values into DB
+    with orm.db_session:
+        # of our new transaction risk
+        tx_risk = TransactionRisk(
+            hash=tx.hash,
+            risk=risk,
+            live_time=live_time,
+            global_mean=mean,
+            global_variance=variance,
+            global_counted_txs=counted_txs,
+        )
+
+        # and also of the node, which is responsible for that transaction
+        if too_low or too_big:
+            author_node = NodeRisk.get(pubkey=node_pubkey)
+            if author_node is None:
+                author_node = NodeRisk(
+                    pubkey=node_pubkey, too_fast_txs=0, too_slow_txs=0
+                )
+            if too_low:
+                author_node.too_fast_txs += 1
+            else:
+                author_node.too_slow_txs += 1
+
+
+def main_loop():
+    try_initialize_globals()
+
+    while True:
+        try:
+            # get the block from some other thread
+            block = TransactionEventQueue.get()
+
+            # update our internal mean-variance state and find outliers
+            for tx in block.transactions:
+                process_transaction(tx, block.validated_by)
+        except Exception as e:
+            LOGGER.error(
+                "exception when calculating the live-time transaction mean&variance happened: {}".format(
+                    str(e)
+                )
+            )
+
+
+def start_live_time_transaction_heuristic():
+    LOGGER.info("Starting LiveTimeTransaction thread...")
+    threading.Thread(target=main_loop, daemon=True).start()

--- a/backend/src/polydash/routers/transaction_risk.py
+++ b/backend/src/polydash/routers/transaction_risk.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, HTTPException
+from pony import orm
+from polydash.model.transaction_risk import TransactionRisk, TransactionRiskOut
+
+router = APIRouter(
+    prefix="/tx_risk",
+    tags=["transactions"],
+    # dependencies=[Depends(get_token_header)],
+    responses={
+        404: {"description": "Not found"},
+        422: {"description": "Bad value in request"},
+    },
+)
+
+
+@router.get("")
+async def get_all_txs():
+    with orm.db_session:
+        txs = TransactionRisk.select()
+        result = [TransactionRiskOut.from_orm(tx) for tx in txs]
+    return result
+
+
+@router.get("/latest/{n}")
+async def get_latest_n(n: int):
+    if n <= 0:
+        raise HTTPException(
+            status_code=422, detail="Number of transactions must be greater than 0"
+        )
+    with orm.db_session:
+        txs = TransactionRisk.select_by_sql(
+            "SELECT * from TransactionRisk ORDER BY id DESC LIMIT {}".format(n)
+        )
+        result = [TransactionRiskOut.from_orm(tx) for tx in txs]
+    return result
+
+
+@router.get("/latest/risked/{n}")
+async def get_latest_risked_txs_n(n: int):
+    """
+    Risks: 0 means transaction was too fast, 1 means transaction was too slow
+    """
+    if n <= 0:
+        raise HTTPException(
+            status_code=422, detail="Number of transactions must be greater than 0"
+        )
+    with orm.db_session:
+        txs = TransactionRisk.select_by_sql(
+            "SELECT * from TransactionRisk WHERE risk IS NOT NULL ORDER BY id DESC LIMIT {}".format(
+                n
+            )
+        )
+        result = [TransactionRiskOut.from_orm(tx) for tx in txs]
+    return result
+
+
+@router.get("/{tx_hash}")
+async def get_tx(tx_hash: str):
+    with orm.db_session:
+        node = TransactionRisk[tx_hash]
+        result = TransactionRiskOut.from_orm(node)
+    return result

--- a/backend/src/polydash/tests/test_mean_variance_function.py
+++ b/backend/src/polydash/tests/test_mean_variance_function.py
@@ -1,0 +1,53 @@
+import pytest
+
+from polydash.rating.live_time_transaction import calculate_mean_variance
+
+
+@pytest.fixture
+def mean_variance_test_fixture():
+    pass
+
+
+def test_mean_variance_calculation(mean_variance_test_fixture):
+    mean, variance, counted, too_low, too_big = calculate_mean_variance(1, 0, 0, 0)
+    assert mean == 1
+    assert variance == 0
+    assert counted == 1
+    assert not too_low
+    assert not too_big
+
+    mean, variance, counted, too_low, too_big = calculate_mean_variance(
+        2, mean, variance, counted
+    )
+    assert round(mean, 2) == 1.5
+    assert round(variance, 2) == 0.25
+    assert counted == 2
+    assert not too_low
+    assert not too_big
+
+    mean, variance, counted, too_low, too_big = calculate_mean_variance(
+        3, mean, variance, counted
+    )
+    assert round(mean, 2) == 2
+    assert round(variance, 2) == 0.67
+    assert counted == 3
+    assert not too_low
+    assert not too_big
+
+    mean, variance, counted, too_low, too_big = calculate_mean_variance(
+        10, mean, variance, counted
+    )
+    assert round(mean, 2) == 4
+    assert round(variance, 2) == 12.5
+    assert counted == 4
+    assert not too_low
+    assert too_big
+
+    mean, variance, counted, too_low, too_big = calculate_mean_variance(
+        -10, mean, variance, counted
+    )
+    assert round(mean, 2) == 1.2
+    assert round(variance, 2) == 41.36
+    assert counted == 5
+    assert too_low
+    assert not too_big


### PR DESCRIPTION
This PR adds the following:
- new transaction risk heuristic (`TransactionRisk` table in DB); now one can retrieve the list of transactions with their live-times, mean/variance and deviations *globally* and not related to peer as in the previous heuristic
- another mean of node risk calculation (`NodeRisk` table in DB); it shows how many too slow or too fast transactions the peer has committed in relation to the whole seen transactions set
- endpoints to retrieve both of these tables

Things to yet be done in this PR (open for discussion):
- quantiles of the transactions (e.g. top 1% of the fastest) in addition to just the 3 standard deviations