### PR TITLE
Add IPs to the response of deanon router

### DIFF
--- a/backend/src/polydash/routers/deanon.py
+++ b/backend/src/polydash/routers/deanon.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter, HTTPException
 from pony import orm
+from pydantic import BaseModel
+from typing import List
 
 from polydash.model.deanon_node_by_tx import DeanonNodeByTx, DeanonNodeByTxInDB
 from polydash.model.deanon_node_by_block import DeanonNodeByBlock, DeanonNodeByBlockInDB
+from polydash.model.peer_to_ip import PeerToIP, PeerToIPInDB
 
 router = APIRouter(
     prefix="/deanon",
@@ -12,59 +15,103 @@ router = APIRouter(
 )
 
 
+class DeanonNodeByTxWithIP(BaseModel):
+    node: DeanonNodeByTxInDB
+    ips: List[str]
+
+
+def get_list_of_deanon_nodes_by_txs_with_ips(nodes_from_db):
+    """
+    Helper function to find IPs of the nodes and pack them into HTTP response
+    """
+    result = []
+    for node in nodes_from_db:
+        ips = [
+            PeerToIPInDB.from_orm(ip).ip for ip in PeerToIP.select(peer_id=node.peer_id)
+        ]
+        result.append(
+            DeanonNodeByTxWithIP(node=DeanonNodeByTxInDB.from_orm(node), ips=ips)
+        )
+    return result
+
+
 @router.get("/by_txs")
 async def get_all_mappings_by_txs():
     with orm.db_session:
-        nodes = DeanonNodeByTx.select().sort_by(orm.desc(DeanonNodeByTx.confidence))
-        result = [DeanonNodeByTxInDB.from_orm(n) for n in nodes]
+        result = get_list_of_deanon_nodes_by_txs_with_ips(
+            DeanonNodeByTx.select().sort_by(orm.desc(DeanonNodeByTx.confidence))
+        )
     return result
 
 
 @router.get("/by_txs/by_pubkey/{pubkey}")
 async def get_by_txs_by_pubkey(pubkey: str):
     with orm.db_session:
-        nodes = DeanonNodeByTx.select(signer_key=pubkey).sort_by(
-            orm.desc(DeanonNodeByTx.confidence)
+        result = get_list_of_deanon_nodes_by_txs_with_ips(
+            DeanonNodeByTx.select(signer_key=pubkey).sort_by(
+                orm.desc(DeanonNodeByTx.confidence)
+            )
         )
-        result = [DeanonNodeByTxInDB.from_orm(n) for n in nodes]
     return result
 
 
 @router.get("/by_txs/by_peer_id/{peer_id}")
 async def get_by_txs_by_peer_id(peer_id: str):
     with orm.db_session:
-        nodes = DeanonNodeByTx.select(peer_id=peer_id).sort_by(
-            orm.desc(DeanonNodeByTx.confidence)
+        result = get_list_of_deanon_nodes_by_txs_with_ips(
+            DeanonNodeByTx.select(peer_id=peer_id).sort_by(
+                orm.desc(DeanonNodeByTx.confidence)
+            )
         )
-        result = [DeanonNodeByTxInDB.from_orm(n) for n in nodes]
+    return result
+
+
+class DeanonNodeByBlockWithIP(BaseModel):
+    node: DeanonNodeByBlockInDB
+    ips: List[str]
+
+
+def get_list_of_deanon_nodes_by_blocks_with_ips(nodes_from_db):
+    """
+    Helper function to find IPs of the nodes and pack them into HTTP response
+    """
+    result = []
+    for node in nodes_from_db:
+        ips = [
+            PeerToIPInDB.from_orm(ip).ip for ip in PeerToIP.select(peer_id=node.peer_id)
+        ]
+        result.append(
+            DeanonNodeByBlockWithIP(node=DeanonNodeByBlockInDB.from_orm(node), ips=ips)
+        )
     return result
 
 
 @router.get("/by_blocks")
 async def get_all_mappings_by_blocks():
     with orm.db_session:
-        nodes = DeanonNodeByBlock.select().sort_by(
-            orm.desc(DeanonNodeByBlock.confidence)
+        result = get_list_of_deanon_nodes_by_blocks_with_ips(
+            DeanonNodeByBlock.select().sort_by(orm.desc(DeanonNodeByBlock.confidence))
         )
-        result = [DeanonNodeByBlockInDB.from_orm(n) for n in nodes]
     return result
 
 
 @router.get("/by_blocks/by_pubkey/{pubkey}")
 async def get_by_blocks_by_pubkey(pubkey: str):
     with orm.db_session:
-        nodes = DeanonNodeByBlock.select(signer_key=pubkey).sort_by(
-            orm.desc(DeanonNodeByBlock.confidence)
+        result = get_list_of_deanon_nodes_by_blocks_with_ips(
+            DeanonNodeByBlock.select(signer_key=pubkey).sort_by(
+                orm.desc(DeanonNodeByBlock.confidence)
+            )
         )
-        result = [DeanonNodeByBlockInDB.from_orm(n) for n in nodes]
     return result
 
 
 @router.get("/by_blocks/by_peer_id/{peer_id}")
 async def get_by_blocks_by_peer_id(peer_id: str):
     with orm.db_session:
-        nodes = DeanonNodeByBlock.select(peer_id=peer_id).sort_by(
-            orm.desc(DeanonNodeByBlock.confidence)
+        result = get_list_of_deanon_nodes_by_blocks_with_ips(
+            DeanonNodeByBlock.select(peer_id=peer_id).sort_by(
+                orm.desc(DeanonNodeByBlock.confidence)
+            )
         )
-        result = [DeanonNodeByBlockInDB.from_orm(n) for n in nodes]
     return result


### PR DESCRIPTION
We also wanted the IP addresses of the nodes to be part of Deanon Router response. The example object from the response:
```
{
    "node": {
      "id": 15,
      "signer_key": "0x7c7379531b2aee82e4ca06d4175d13b9cbeafd49",
      "peer_id": "d87941daca571d4b56c8bb885978c8b6465de035e81cc7f6639b35d0589f770c",
      "confidence": 8
    },
    "ips": [
      "54.242.117.20:42282"
    ]
  }
```