### PR TITLE
Implement the W3Router Watcher

### DIFF
--- a/backend/src/polydash/__main__.py
+++ b/backend/src/polydash/__main__.py
@@ -8,6 +8,7 @@ from polydash.db import start_db
 from polydash.block_retriever.retriever import BlockRetriever
 from polydash.rating.live_rating import start_live_time_rating_calc
 from polydash.deanonymize.deanonymizer import start_deanonymizer
+from polydash.w3router_watcher.w3router_watcher import start_w3router_watcher
 import click
 
 # FastAPI set up
@@ -43,6 +44,7 @@ def start(settings) -> PolydashSettings:
     BlockRetriever(s.block_retriever).start()
     start_deanonymizer()
     start_live_time_rating_calc()
+    start_w3router_watcher()
 
     uvicorn.run(app, host=s.host, port=s.port)
 

--- a/backend/src/polydash/block_retriever/retriever.py
+++ b/backend/src/polydash/block_retriever/retriever.py
@@ -15,6 +15,7 @@ from polydash.rating.live_time_heuristic_a import BlockPoolHeuristicQueue
 from polydash.deanonymize.deanonymizer import DeanonymizerQueue
 from polydash.settings import BlockRetrieverSettings
 from polydash.rating.live_rating import TransactionEventQueue
+from polydash.w3router_watcher.w3router_watcher import W3RouterEventQueue
 
 alchemy_token = ""
 
@@ -173,6 +174,9 @@ class BlockRetriever:
                     TransactionEventQueue.put(
                         block_number
                     )  # put the block for the Transaction Risks to work
+                    W3RouterEventQueue.put(
+                        block_number
+                    )  # put the block for W3Router Watcher to work
                 self.__logger.debug(
                     "retrieved and saved into DB block with number {} and hash {}".format(
                         block_number, block_hash

--- a/backend/src/polydash/w3router_watcher/w3router_watcher.py
+++ b/backend/src/polydash/w3router_watcher/w3router_watcher.py
@@ -1,0 +1,127 @@
+import queue
+import threading
+import traceback
+import requests
+
+from pony import orm
+
+from polydash.log import LOGGER
+from polydash.model.risk import MinerRisk
+from polydash.model.deanon_node_by_tx import DeanonNodeByTx
+from polydash.model.deanon_node_by_block import DeanonNodeByBlock
+from polydash.model.peer_to_ip import PeerToIP
+
+W3RouterEventQueue = queue.Queue()
+
+TOP_NODES_LIST_SIZE = 10
+
+
+class W3RouterWatcher:
+    """
+    Purpose of this class is to recalculate the list of the most trusted nodes every time a new block
+    is received and, if there are any changes, push them into the W3Router itself
+    """
+
+    last_top_nodes_list = []
+
+    def send_nodes_to_router(self):
+        LOGGER.info(
+            "Sending new list of nodes to the W3Router: {}".format(
+                self.last_top_nodes_list
+            )
+        )
+        response = requests.post(
+            "http://localhost/rpc/update_nodes", json=self.last_top_nodes_list
+        )
+        if response.status_code != 200:
+            LOGGER.error(
+                "W3Router has returned {} as status code".format(response.status_code)
+            )
+
+    def check_top_nodes(self):
+        global TOP_NODES_LIST_SIZE
+
+        new_top_nodes = {}
+        top_nodes_select_offset = 0
+        current_priority = 1
+
+        while True:
+            if len(new_top_nodes) >= TOP_NODES_LIST_SIZE:
+                break
+
+            # get the list from the DB
+            new_top_nodes_from_db = MinerRisk.select_by_sql(
+                "SELECT * FROM minerrisk ORDER BY risk DESC LIMIT {} OFFSET {}".format(
+                    TOP_NODES_LIST_SIZE, top_nodes_select_offset
+                )
+            )
+            top_nodes_select_offset += TOP_NODES_LIST_SIZE
+            if len(new_top_nodes_from_db) == 0:
+                # we have exhausted the list of the nodes
+                break
+
+            # build a new list, including the IP addresses
+            for node in new_top_nodes_from_db:
+                # try to get peer ID of the node using two tables
+                deanoned_node = (
+                    DeanonNodeByBlock.select(signer_key=node.pubkey)
+                    .order_by(orm.desc(DeanonNodeByBlock.confidence))
+                    .limit(1)
+                )
+                if len(deanoned_node) == 0:
+                    deanoned_node = (
+                        DeanonNodeByTx.select(signer_key=node.pubkey)
+                        .order_by(orm.desc(DeanonNodeByTx.confidence))
+                        .limit(1)
+                    )
+                if len(deanoned_node) == 0:
+                    # we don't know peer ID of this node, moving on
+                    continue
+
+                # now, try to get IP address of that node
+                node_ip = (
+                    PeerToIP.select(peer_id=deanoned_node[0].peer_id)
+                    .order_by(orm.desc(PeerToIP.id))
+                    .limit(1)
+                )
+                if len(node_ip) == 0:
+                    # we don't know IP of this node, moving on
+                    continue
+
+                # we have found IP of that node, memorize it if it wasn't in the list before
+                ip = node_ip[0].ip
+                if ip in new_top_nodes.values():
+                    continue
+                new_top_nodes[current_priority] = ip
+                current_priority += 1
+
+                # if we have gathered enough nodes information, finish
+                if len(new_top_nodes) >= TOP_NODES_LIST_SIZE:
+                    break
+
+        if new_top_nodes != self.last_top_nodes_list:
+            self.last_top_nodes_list = new_top_nodes
+            self.send_nodes_to_router()
+
+
+def main_loop():
+    watcher = W3RouterWatcher()
+    while True:
+        try:
+            # get the block from some other thread; we're not really going to use the block number (at least for now),
+            # but we want to receive the notification itself
+            _ = W3RouterEventQueue.get()
+            with orm.db_session:
+                watcher.check_top_nodes()
+        except Exception as e:
+            traceback.print_exc()
+            LOGGER.error(
+                "exception when checking for the top nodes in W3Router Watcher happened: {}".format(
+                    str(e)
+                )
+            )
+
+
+def start_w3router_watcher():
+    LOGGER.info("Starting W3Router Watcher thread...")
+    threading.Thread(target=main_loop, daemon=True).start()


### PR DESCRIPTION
When the list of Top-10 miners changes (rating, IP addresses), the corresponding request must be sent to the router with the updated information about the priorities.